### PR TITLE
fix: Correct async handling in assertErrorFail tests

### DIFF
--- a/tests/assertions/assert-errors-test.ts
+++ b/tests/assertions/assert-errors-test.ts
@@ -12,27 +12,27 @@ export function assertErrorPass() {
     shouldFailWithArgs(testFunction, [1,2], "expected: 1 actual: 2 ");
 }
 
-export function assertErrorFail() {
+export async function assertErrorFail() {
     const testFunction = (a,b) => { equals(a,b); };
 
     try {
-        shouldFailWithArgs( (a, b ) => { new Error()}, [1,1]);
+        await shouldFailWithArgs( (a, b ) => { new Error()}, [1,1]);
         throw new TestRunnerExpectedError("Error: Fail expected, function shouldn't throw an error");
     } catch {}
 
 
     try {
-        shouldFailWithArgs(testFunction, [1,1]);
+        await shouldFailWithArgs(testFunction, [1,1]);
         throw new TestRunnerExpectedError("Error: Fail expected, function shouldn't throw an error");
     } catch {}
 
     try {
-        shouldFailWithArgs(testFunction, [1,1, "s"], "Error: Fail expected");
+        await shouldFailWithArgs(testFunction, [1,1, "s"], "Error: Fail expected");
         throw new TestRunnerExpectedError("Error: Fail expected, 3 args given, but 2 are required");
     } catch {}
 
     try {
-        shouldFailWithArgs(testFunction, null, "Error: Fail expected");
+        await shouldFailWithArgs(testFunction, null, "Error: Fail expected");
         throw new TestRunnerExpectedError("Error: Fail expected, null args provided, 2 are required");
     } catch {}
 }


### PR DESCRIPTION
This commit updates the `assertErrorFail` function in `tests/assertions/assert-errors-test.ts` to correctly handle asynchronous assertion functions (`shouldFail` and `shouldFailWithArgs`).

The `assertErrorFail` function is now marked as `async`, and all calls to `shouldFail` and `shouldFailWithArgs` within its `try...catch` blocks are now `await`ed.

This ensures that the `try...catch` blocks properly capture rejections from these promise-returning assertion functions, allowing the test logic (which expects these assertions to sometimes fail and throw errors) to work as intended. This resolves a test failure where errors thrown by `shouldFailWithArgs` were not being caught correctly.