### PR TITLE
fix: Enable asynchronous test execution and update JSDoc

### DIFF
--- a/src/runner/interface.ts
+++ b/src/runner/interface.ts
@@ -5,46 +5,34 @@ import { showTestRunnerResults } from "./results/test-runner-results-summary";
 /**
  * Defines and registers a test case with the test runner.
  * The test execution function can contain assertions and other test logic.
- * It receives a `logs` array to which custom log messages can be pushed during the test.
- * 
- * Note: While the `execution` function itself is currently processed synchronously by `processTest`,
- * for asynchronous operations within a test (e.g., awaiting promises), ensure that
- * `processTest` is adapted or the overall test runner handles promise resolutions
- * or rejections from `execution` if it were to return a Promise. The `test` function
- * itself does not currently await or handle promises returned by `execution`.
+ * It can be synchronous or asynchronous (return a Promise). If it returns a Promise,
+ * the test runner will await its settlement.
+ * The execution function receives a `logs` array to which custom log messages can be pushed.
  *
  * @param {string} name - A descriptive name or title for the test case. This corresponds to the `info` parameter of `processTest`.
- * @param {(logs: string[] | null) => void} execution - The function containing the test logic. This corresponds to the `func` parameter of `processTest`.
- *                                                   It receives an array for logging; push messages to it.
- *                                                   Throw an error within this function to fail the test.
+ * @param {(logs: string[] | null) => void | Promise<void>} execution - The function containing the test logic.
+ *                                                                    It receives an array for logging.
+ *                                                                    Throw an error or return a rejected Promise to fail the test.
  * @example
- * import { test, equals } from 'naive-tests-ts'; // Assuming 'equals' is an available assertion
+ * import { test, equals } from 'naive-tests-ts';
  *
+ * // Synchronous test
  * test("should correctly add two numbers", (logs) => {
  *   const result = 2 + 2;
- *   logs?.push(`Calculation: 2 + 2 = ${result}`); // Optional logging
- *   equals(result, 4); // Assertion
+ *   logs?.push(`Calculation: 2 + 2 = ${result}`);
+ *   equals(result, 4);
  * });
  * 
- * test("example of a test that might fail", (logs) => {
- *   logs?.push("Attempting a risky operation...");
- *   equals(true, false, "This assertion will fail");
+ * // Asynchronous test
+ * test("should handle asynchronous operations", async (logs) => {
+ *   const delayedResult = await new Promise(resolve => setTimeout(() => resolve(5), 50));
+ *   logs?.push(`Async result: ${delayedResult}`);
+ *   equals(delayedResult, 5);
  * });
- * 
- * // For asynchronous code within 'execution':
- * // test("async conceptual test", (logs) => {
- * //   myAsyncFunction().then(result => {
- * //     logs?.push(`Async result: ${result}`);
- * //     equals(result, expectedAsyncResult);
- * //   }).catch(error => {
- * //     logs?.push(`Async error: ${error.message}`);
- * //     throw error; // Ensure the test fails by re-throwing or throwing a new error
- * //   });
- * //   // IMPORTANT: The 'test' function itself does not wait for promises from 'execution'.
- * //   // The above async pattern might lead to tests finishing before async code completes
- * //   // or error handling issues if not managed carefully within 'execution',
- * //   // unless processTest is enhanced to handle promises from 'execution'.
- * // });
+ *
+ * test("example of a failing asynchronous test", async (logs) => {
+ *   await new Promise((_, reject) => setTimeout(() => reject(new Error("Async task failed")), 10));
+ * });
  */
 export const test: typeof processTest = processTest;
 

--- a/src/runner/process/test-process.ts
+++ b/src/runner/process/test-process.ts
@@ -2,13 +2,16 @@ import { TestRunnerError } from "./errors";
 import { TestResult } from "../results/test-result";
 import { TestRunner } from "./test-runner";
 
-export function processTest(info: string, func: (logs: Array<string> | null) => void) {
+export async function processTest(info: string, func: (logs: Array<string> | null) => void | Promise<void>) {
     const start = Date.now();
     const errors = Array<string>();
     const logs = new Array<string>();
 
     try {
-        func(logs);
+        const result = func(logs);
+        if (result && typeof result.then === 'function' && typeof result.catch === 'function') {
+            await result;
+        }
         const time = `${(Date.now() - start) / 1000} sec`;
         TestRunner.addResult(new TestResult(info, time, errors, logs));
     }


### PR DESCRIPTION
This commit modifies the test runner to correctly handle asynchronous test functions (those returning a Promise).

Modifications:
- `src/runner/process/test-process.ts`:
    - The `processTest` function is now `async`.
    - It now checks if the test function (`func`) returns a Promise.
    - If a Promise is returned, `processTest` awaits its settlement, ensuring that asynchronous operations within tests complete and any rejections are correctly caught as test failures.
    - The type annotation for `func` has been updated to `(logs: Array<string> | null) => void | Promise<void>`.

- `src/runner/interface.ts`:
    - The JSDoc for the `test` function (which aliases `processTest`) has been updated to reflect its new capability to handle and await `async` test functions.
    - The previous warning about synchronous-only execution has been removed.
    - Examples have been updated to better showcase async test usage.

This resolves issues where asynchronous tests were not being correctly processed, leading to inaccurate test results.